### PR TITLE
Fix openpyxl to older working version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     download_url='https://github.com/tarkatronic/django-excel-response/archive/master.tar.gz',
     install_requires=[
         'Django>=1.8',
-        'openpyxl'
+        'openpyxl==2.4.10'
     ],
 
     classifiers=[


### PR DESCRIPTION
The new version of openpyxl has removed the 'openpyxl.writer.write_only' package, this changes pins the requirement to the older version until a more comprehensive fix can be made.