### PR TITLE
Allow openpyxl versions >= 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 - 3.4
 - 3.5
 - 3.6
+- pypy3
 env:
 - DJANGO=1.8
 - DJANGO=1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 python:
 - 2.7
-- 3.3
 - 3.4
 - 3.5
 - 3.6
@@ -16,14 +15,6 @@ env:
 matrix:
   exclude:
   - python: 2.7
-    env: DJANGO=2.0
-  - python: 3.3
-    env: DJANGO=1.9
-  - python: 3.3
-    env: DJANGO=1.10
-  - python: 3.3
-    env: DJANGO=1.11
-  - python: 3.3
     env: DJANGO=2.0
   - python: 3.6
     env: DJANGO=1.8

--- a/excel_response/response.py
+++ b/excel_response/response.py
@@ -7,7 +7,12 @@ import six
 from django.http.response import HttpResponse
 from openpyxl import Workbook
 from openpyxl.writer.excel import save_virtual_workbook
-from openpyxl.writer.write_only import WriteOnlyCell
+
+
+try:
+    from openpyxl.worksheet.write_only import WriteOnlyCell
+except ImportError:
+    from openpyxl.writer.write_only import WriteOnlyCell
 
 
 if django.VERSION >= (1, 9):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     download_url='https://github.com/tarkatronic/django-excel-response/archive/master.tar.gz',
     install_requires=[
         'Django>=1.8',
-        'openpyxl<2.5'
+        'openpyxl'
     ],
 
     classifiers=[
@@ -39,15 +39,17 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Framework :: Django',
         'Framework :: Django :: 1.8',
         'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
+        'Framework :: Django :: 2.0',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Office/Business :: Financial :: Spreadsheet',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py{27,33,34,35}-django18
-    py{27,34,35}-django{19,110}
-    py{27,34,35,36}-django111
-    py{34,35,36}-django20
-    py{35,36}-djangomaster,
+    py{27,34,35,py3}-django18
+    py{27,34,35,py3}-django{19,110}
+    py{27,34,35,36,py3}-django111
+    py{34,35,36,py3}-django20
+    py{35,36,py3}-djangomaster,
     flake8
 skip_missing_interpreters = true
 
@@ -15,15 +15,15 @@ setenv =
     COVERAGE_PROCESS_START=.coveragerc
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    pypy3: pypy3
 deps =
     coverage_pth
     et-xmlfile
     jdcal
-    openpyxl<2.5
+    openpyxl
     six
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.110
@@ -55,6 +55,7 @@ python =
     3.4: py34
     3.5: py35
     3.6: py36, flake8
+    pypy3: pypy3
 
 [travis:env]
 DJANGO =


### PR DESCRIPTION
This meant dropping support for Python 3.3, which I'm totally okay with. I also added pypy3 to the testing matrix, mostly because I could.