### PR TITLE
Proposing a fix for issues#16

### DIFF
--- a/excel_response/response.py
+++ b/excel_response/response.py
@@ -26,13 +26,14 @@ class ExcelResponse(HttpResponse):
     """
 
     def __init__(self, data, output_filename='excel_data', worksheet_name=None, force_csv=False, header_font=None,
-                 data_font=None, *args, **kwargs):
+                 data_font=None, guess_types=True, *args, **kwargs):
         # We do not initialize this with streaming_content, as that gets generated when needed
         self.output_filename = output_filename
         self.worksheet_name = worksheet_name or 'Sheet 1'
         self.header_font = header_font
         self.data_font = data_font
         self.force_csv = force_csv
+        self.guess_types = guess_types
         super(ExcelResponse, self).__init__(data, *args, **kwargs)
 
     @property
@@ -80,7 +81,7 @@ class ExcelResponse(HttpResponse):
             write_header = append
         else:
             workbook = Workbook(write_only=True)
-            workbook.guess_types = True
+            workbook.guess_types = self.guess_types
             worksheet = workbook.create_sheet(title=self.worksheet_name)
 
             # Define custom functions for appending so that we can handle any formatting

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -177,7 +177,7 @@ class ExcelResponseExcelTest(TestCase):
 
     def test_create_excel_with_guess_types_on(self):
         r = response.ExcelResponse(
-            [['a', 'b', 'c'], [2018032710050111540290000000000720000000023, 2, 3], [4, 5, 6]]
+            [['a', 'b', 'c'], ['2018032710050111540290000000000720000000023', 2, 3], [4, 5, 6]]
         )
         output = six.BytesIO(r.getvalue())
         # This should theoretically raise errors if it's not a valid spreadsheet

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -175,6 +175,29 @@ class ExcelResponseExcelTest(TestCase):
         cell = sheet['A2']
         self.assertEqual(cell.font.name, 'Windings')
 
+    def test_create_excel_with_guess_types_on(self):
+        r = response.ExcelResponse(
+            [['a', 'b', 'c'], [2018032710050111540290000000000720000000023, 2, 3], [4, 5, 6]]
+        )
+        output = six.BytesIO(r.getvalue())
+        # This should theoretically raise errors if it's not a valid spreadsheet
+        wb = openpyxl.load_workbook(output, read_only=True)
+        ws = wb.active
+        self.assertEqual((ws['A1'].value, ws['B1'].value, ws['C1'].value), ('a', 'b', 'c'))
+        self.assertEqual((ws['A2'].value, ws['B2'].value, ws['C2'].value), (2.018032710050112e+42, 2, 3))
+
+    def test_create_excel_with_guess_types_off(self):
+        r = response.ExcelResponse(
+            [['a', 'b', 'c'], ['2018032710050111540290000000000720000000023', 2, 3], [4, 5, 6]], guess_types=False
+        )
+        output = six.BytesIO(r.getvalue())
+        # This should theoretically raise errors if it's not a valid spreadsheet
+        wb = openpyxl.load_workbook(output, read_only=True)
+        ws = wb.active
+        self.assertEqual((ws['A1'].value, ws['B1'].value, ws['C1'].value), ('a', 'b', 'c'))
+        self.assertEqual((ws['A2'].value, ws['B2'].value, ws['C2'].value),
+                         ('2018032710050111540290000000000720000000023', 2, 3))
+
 
 class CBVTest(TestCase):
 


### PR DESCRIPTION
I have been struggling with issues where excel converts big numbers to scientific format. e.g. `200420340204032403204` into `2.0042E+20`. And it's really painful to convert it back to original textual format. 

I need an option in `ExcelResponse` to control this behaviour. 